### PR TITLE
chore: shorten container name to bypass admission webhook

### DIFF
--- a/dex-group-authentication/promise.yaml
+++ b/dex-group-authentication/promise.yaml
@@ -203,10 +203,10 @@ spec:
       - apiVersion: platform.kratix.io/v1alpha1
         kind: Pipeline
         metadata:
-          name: instance-configure
+          name: instance-config
           namespace: default
         spec:
           containers:
           - image: ghcr.io/syntasso/kratix-marketplace/dex-group-authentication-configure-pipeline:v0.1.0
-            name: dex-group-authentication-configure-pipeline
+            name: dex-group-auth-config-pipeline
 status: {}


### PR DESCRIPTION
Example error: 
<img width="922" alt="image" src="https://github.com/user-attachments/assets/a1e4e141-f9c0-471c-bc2e-425e05f8d9a7">