### PR TITLE
chore: rename all references to kratix-bucket to kratix

### DIFF
--- a/vcluster/internal/configure-pipeline/resources/flux-push.yaml
+++ b/vcluster/internal/configure-pipeline/resources/flux-push.yaml
@@ -14,7 +14,6 @@ spec:
     name: kratix
     namespace: flux-system
   path: ./CLUSTERNAME/resources
-  validation: client
   kubeConfig:
     secretRef:
       name: vc-CLUSTERNAME-flux
@@ -32,7 +31,6 @@ spec:
     kind: Bucket
     name: kratix
     namespace: flux-system
-  validation: client
   path: ./CLUSTERNAME/dependencies
   kubeConfig:
     secretRef:

--- a/vcluster/internal/configure-pipeline/resources/flux-push.yaml
+++ b/vcluster/internal/configure-pipeline/resources/flux-push.yaml
@@ -11,7 +11,7 @@ spec:
     - name: CLUSTERNAME-dependencies
   sourceRef:
     kind: Bucket
-    name: kratix-bucket
+    name: kratix
     namespace: flux-system
   path: ./CLUSTERNAME/resources
   validation: client
@@ -30,7 +30,7 @@ spec:
   prune: true
   sourceRef:
     kind: Bucket
-    name: kratix-bucket
+    name: kratix
     namespace: flux-system
   validation: client
   path: ./CLUSTERNAME/dependencies


### PR DESCRIPTION
this is a cross repo change and depends on the change in kratix to the quickstart