### PR TITLE
♻️ Support Architectures beyond AMD64

### DIFF
--- a/ansible-job-launcher/internal/configure-pipeline/Dockerfile
+++ b/ansible-job-launcher/internal/configure-pipeline/Dockerfile
@@ -1,10 +1,13 @@
+# NOTE base image only available for linux/amd64
 FROM t42x/awxkit_base:23.5.1
 LABEL org.opencontainers.image.authors="kratix@syntasso.io"
 LABEL org.opencontainers.image.source=https://github.com/syntasso/kratix-marketplace
 
 USER root
 RUN apk add curl jq yq
-RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
+# NOTE requires buildx
+ARG TARGETARCH
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${TARGETARCH}/kubectl" && \
     install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 RUN [ "mkdir", "/tmp/transfer" ]
 

--- a/pipeline-marketplace-images/sealedsecrets/Dockerfile
+++ b/pipeline-marketplace-images/sealedsecrets/Dockerfile
@@ -5,8 +5,10 @@ LABEL org.opencontainers.image.source=https://github.com/syntasso/kratix-marketp
 
 ADD execute-pipeline execute-pipeline
 
-ENV KUBESEAL_VERSION 0.24.1
-RUN curl -Lo kubeseal.tar.gz https://github.com/bitnami-labs/sealed-secrets/releases/download/v${KUBESEAL_VERSION}/kubeseal-${KUBESEAL_VERSION}-linux-amd64.tar.gz
+ARG KUBESEAL_VERSION=0.24.1
+# NOTE requires buildx
+ARG TARGETARCH
+RUN curl -Lo kubeseal.tar.gz https://github.com/bitnami-labs/sealed-secrets/releases/download/v${KUBESEAL_VERSION}/kubeseal-${KUBESEAL_VERSION}-linux-${TARGETARCH}.tar.gz
 RUN tar -xvzf kubeseal.tar.gz kubeseal && chmod u+x kubeseal && mv kubeseal /bin/kubeseal
 
 CMD [ "sh", "-c", "./execute-pipeline" ]

--- a/pipeline-marketplace-images/vault/Dockerfile
+++ b/pipeline-marketplace-images/vault/Dockerfile
@@ -4,7 +4,9 @@ LABEL org.opencontainers.image.authors="kratix@syntasso.io"
 LABEL org.opencontainers.image.source=https://github.com/syntasso/kratix-marketplace
 
 ADD execute-pipeline execute-pipeline
-RUN curl https://releases.hashicorp.com/vault/1.16.2/vault_1.16.2_linux_amd64.zip -o vault.zip && unzip vault.zip && mv vault /usr/sbin/vault && rm vault.zip
+# NOTE requires buildx
+ARG TARGETARCH
+RUN curl https://releases.hashicorp.com/vault/1.16.2/vault_1.16.2_linux_${TARGETARCH}.zip -o vault.zip && unzip vault.zip && mv vault /usr/sbin/vault && rm vault.zip
 
 CMD [ "sh", "-c", "./execute-pipeline" ]
 ENTRYPOINT []

--- a/slack/internal/configure-pipeline/Dockerfile
+++ b/slack/internal/configure-pipeline/Dockerfile
@@ -6,7 +6,9 @@ LABEL org.opencontainers.image.source=https://github.com/syntasso/kratix-marketp
 RUN [ "mkdir", "/tmp/transfer" ]
 RUN apk update && apk add --no-cache yq curl git
 
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.25.1/bin/linux/amd64/kubectl
+# NOTE requires buildx
+ARG TARGETARCH
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.25.1/bin/linux/${TARGETARCH}/kubectl
 RUN chmod u+x kubectl && mv kubectl /bin/kubectl
 
 ADD resources/* /tmp/transfer/

--- a/vault-namespace/internal/configure-pipeline/Dockerfile
+++ b/vault-namespace/internal/configure-pipeline/Dockerfile
@@ -1,4 +1,4 @@
-FROM vault:1.13.3 as vault
+FROM vault:1.13.3 AS vault
 FROM alpine
 
 COPY --from=vault /bin/vault /usr/bin/vault
@@ -9,7 +9,9 @@ LABEL org.opencontainers.image.source=https://github.com/syntasso/kratix-marketp
 RUN [ "mkdir", "/tmp/transfer" ]
 RUN apk update && apk add --no-cache yq curl libcap
 
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.25.1/bin/linux/amd64/kubectl
+# NOTE requires buildx
+ARG TARGETARCH
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.25.1/bin/linux/${TARGETARCH}/kubectl
 RUN chmod u+x kubectl && mv kubectl /bin/kubectl
 
 ADD execute-pipeline execute-pipeline

--- a/vcluster/internal/configure-pipeline/Dockerfile
+++ b/vcluster/internal/configure-pipeline/Dockerfile
@@ -14,7 +14,9 @@ RUN apk add curl openssl bash --no-cache
 RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 \
     && chmod +x get_helm.sh && ./get_helm.sh
 
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.25.1/bin/linux/amd64/kubectl
+# NOTE requires buildx
+ARG TARGETARCH
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.25.1/bin/linux/${TARGETARCH}/kubectl
 RUN chmod u+x kubectl && mv kubectl /bin/kubectl
 
 CMD [ "sh", "-c", "./execute-pipeline" ]


### PR DESCRIPTION
Some Dockerfile download dependencies outside of
the package manager making assumptions on the
target architecture.

ARM architectures becomes more popular in
cloud services. E.g. it is possible to run Kratix
in AWS EKS using ARM64 based nodes.

The Kratix Marketplace provides reusable promises
to learn and experiment when writing promises.

Where feasible the Dockerfiles can be
architecture agnostic to ease adoption.