### PR TITLE
Quick start evolution

### DIFF
--- a/sql/aws/README.md
+++ b/sql/aws/README.md
@@ -8,18 +8,25 @@ This Promise provides RDS-as-a-Service. The following parameters are available:
 
 ## Pre-requisites
 
-To use this promise, you must have a Access Key and Secret Access Key for your
-AWS account. The IAM user associated with these keys must have the permission to
-create and delete RDS instances.
+To use this promise, you must have:
 
-Create a Kubernetes Secret with the credentials:
+* A Access Key and Secret Access Key for your AWS account with permission to manage RDS instances
+    You can follow AWS documentation, or review the following commands via the AWS CLI:
 
-```bash
-kubectl create secret generic aws-rds \
-    --namespace default \
-    --from-literal=accessKeyID=<your access key> \
-    --from-literal=secretAccessKey=<your secret access key>
-```
+    ```bash
+    export IAM_USER="kratix-$(whoami)-${RANDOM}-rds"
+    aws iam create-user --user-name ${IAM_USER} --no-cli-pager 
+    aws iam attach-user-policy --user-name ${IAM_USER} --policy-arn arn:aws:iam::aws:policy/AmazonRDSFullAccess --no-cli-pager 
+    eval $(aws iam create-access-key --user-name ${IAM_USER} --output text --no-cli-pager --query 'AccessKey.[AccessKeyId,SecretAccessKey]' | \
+        awk '{print "export RDS_KEY_ID=\"" $1 "\"\nexport RDS_SECRET_ACCESS_KEY=\"" $2 "\""}')
+    ```
+* A secret with a key for that service account in your cluster
+    ```bash
+    kubectl create secret generic aws-rds \
+        --namespace default \
+        --from-literal=accessKeyID=${RDS_KEY_ID} \
+        --from-literal=secretAccessKey=${RDS_SECRET_ACCESS_KEY}
+    ```
 
 ## Install Promise
 

--- a/sql/aws/README.md
+++ b/sql/aws/README.md
@@ -1,8 +1,12 @@
 # AWS DB Promise
 
-## Pre-requisites
+This Promise provides RDS-as-a-Service. The following parameters are available:
 
-### Credentials
+* `spec.dbName`: The name of the database to create.
+* `spec.engine`: The database engine to use. Supported values are `mysql`, `postgres`, and `mariadb`.
+* `spec.size`: The size of this deployment. Supported values are `micro`, `small`, `medium`, and `large`.
+
+## Pre-requisites
 
 To use this promise, you must have a Access Key and Secret Access Key for your
 AWS account. The IAM user associated with these keys must have the permission to
@@ -17,13 +21,7 @@ kubectl create secret generic aws-rds \
     --from-literal=secretAccessKey=<your secret access key>
 ```
 
-## Usage
-
-This Promise provides RDS-as-a-Service. The following parameters are available:
-
-* `spec.dbName`: The name of the database to create.
-* `spec.engine`: The database engine to use. Supported values are `mysql`, `postgres`, and `mariadb`.
-* `spec.size`: The size of this deployment. Supported values are `micro`, `small`, `medium`, and `large`.
+## Install Promise
 
 To install:
 ```

--- a/sql/azure/README.md
+++ b/sql/azure/README.md
@@ -5,7 +5,7 @@ which can be `small` or `large`.
 
 ## Prerequisites
 
-Requires a secret for connecting to azure:
+Requires a secret for connecting to azure with permissions to create SQL databases:
 
 ```
 kubectl create secret generic azure-credentials --from-file=key=key.pem \

--- a/sql/azure/README.md
+++ b/sql/azure/README.md
@@ -1,5 +1,10 @@
 # sql
 
+This Promise provides sql-as-a-Service. The Promise has 1 field `.spec.size`
+which can be `small` or `large`.
+
+## Prerequisites
+
 Requires a secret for connecting to azure:
 
 ```
@@ -8,8 +13,7 @@ kubectl create secret generic azure-credentials --from-file=key=key.pem \
     --from-literal=tenantID=<tenantID>
 ```
 
-This Promise provides sql-as-a-Service. The Promise has 1 field `.spec.size`
-which can be `small` or `large`.
+## Install Promise
 
 To install:
 ```

--- a/sql/gcp/README.md
+++ b/sql/gcp/README.md
@@ -1,13 +1,39 @@
 # sql
 
-Requires a secret for connecting to GCP:
-
-```
-kubectl create secret generic gcp-credentials --from-file=credentialsjson=serviceaccount.json --from-literal=project_id=<project-name>
-```
-
 This Promise provides sql-as-a-Service. The Promise has 1 field `.spec.size`
 which can be `small` or `large`.
+
+## Prerequisites
+
+To use this Promise, you will need to create one more secret which is the GCP Service Account permissions needed to create Cloud SQL databases. You can follow Google documentation, or review the following commands via the gcloud CLI:
+
+```bash
+export DIR_GCLOUD_CONFIG="${HOME}/.config/gcloud"
+export GCP_SERVICE_ACCOUNT_NAME="kratix-sql-$(whoami)-14635" # TOOD ${RANDOM}
+export PROJECT_ID=$(sed -n -e 's/^project = //p' ${DIR_GCLOUD_CONFIG}/configurations/config_$(cat ${DIR_GCLOUD_CONFIG}/active_config))
+
+gcloud iam service-accounts create ${GCP_SERVICE_ACCOUNT_NAME} --display-name="Kratix Cloud SQL Manager"
+gcloud projects add-iam-policy-binding ${PROJECT_ID} --member="serviceAccount:${GCP_SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com" --role="roles/cloudsql.admin"
+gcloud iam service-accounts keys create ${DIR_GCLOUD_CONFIG}/kratix-sql-manager-key.json --iam-account "${GCP_SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+```
+
+Once you have the key json stored in `${DIR_GCLOUD_CONFIG}/kratix-sql-manager-key.json` you can use the following command to generate the Kubernetes secret:
+
+```bash
+export DIR_GCLOUD_CONFIG="${HOME}/.config/gcloud"
+export PROJECT_ID=$(sed -n -e 's/^project = //p' ${DIR_GCLOUD_CONFIG}/configurations/config_$(cat ${DIR_GCLOUD_CONFIG}/active_config))
+cat << EOF | kubectl apply -f -
+apiVersion: v1
+data:
+  credentialsjson: $(cat ${DIR_GCLOUD_CONFIG}/kratix-sql-manager-key.json | base64 -w0)
+  project_id: $(echo ${PROJECT_ID} | base64 -w0)
+kind: Secret
+metadata:
+  name: gcp-credentials
+EOF
+```
+
+## Install Promise
 
 To install:
 ```


### PR DESCRIPTION
This PR collaborates with https://github.com/syntasso/kratix-examples/pull/2 and https://github.com/syntasso/kratix-docs/pull/308 to create a more cohesive story around how to manage Kratix in the public clouds.

This is not finished. There is still work to be done to make this entry point smoother and to be clearer about where Kratix ends and tangential tooling (such as GitOps tools) starts.