### PR TITLE
Updating Dapr to 1.16.0 release

### DIFF
--- a/dapr/internal/scripts/fetch-deps
+++ b/dapr/internal/scripts/fetch-deps
@@ -7,7 +7,7 @@ DEPENDENCIES_DIR=${PWD}/configure-pipeline/dependencies
 helm repo add dapr https://dapr.github.io/helm-charts/
 helm repo update
 
-VERSION=1.14.1
+VERSION=1.16.0
 mkdir -p ${DEPENDENCIES_DIR}
 helm show crds dapr/dapr --version ${VERSION} > ${DEPENDENCIES_DIR}/crds.yaml
 DIR=$(mktemp -d)


### PR DESCRIPTION
Simple upgrade to 1.16.0 release. 