### PR TITLE
chore: update Dapr to v1.18.1

### DIFF
--- a/dapr/internal/configure-pipeline/dependencies/crds.yaml
+++ b/dapr/internal/configure-pipeline/dependencies/crds.yaml
@@ -651,6 +651,40 @@ spec:
               workflow:
                 description: WorkflowSpec defines the configuration for Dapr workflows.
                 properties:
+                  activityConcurrencyLimits:
+                    description: |-
+                      activityConcurrencyLimits defines per-activity-name concurrency limits
+                      enforced globally across all replicas by the scheduler.
+                    items:
+                      description: |-
+                        NamedConcurrencyLimit defines a per-name concurrency limit for a specific
+                        workflow or activity name.
+                      properties:
+                        maxConcurrent:
+                          description: |-
+                            MaxConcurrent is the maximum number of concurrent invocations across all
+                            replicas.
+                          format: int32
+                          type: integer
+                        name:
+                          description: Name is the workflow or activity name to limit.
+                          type: string
+                      type: object
+                    type: array
+                  globalMaxConcurrentActivityInvocations:
+                    description: |-
+                      globalMaxConcurrentActivityInvocations is the maximum number of concurrent
+                      activity invocations across all replicas, enforced by the scheduler.
+                      If omitted, no global maximum will be enforced.
+                    format: int32
+                    type: integer
+                  globalMaxConcurrentWorkflowInvocations:
+                    description: |-
+                      globalMaxConcurrentWorkflowInvocations is the maximum number of concurrent
+                      workflow invocations across all replicas, enforced by the scheduler.
+                      If omitted, no global maximum will be enforced.
+                    format: int32
+                    type: integer
                   maxConcurrentActivityInvocations:
                     description: |-
                       maxConcurrentActivityInvocations is the maximum number of concurrent activities that can be processed by a single Dapr instance.
@@ -692,6 +726,26 @@ spec:
                           Terminated terminal state.
                         type: string
                     type: object
+                  workflowConcurrencyLimits:
+                    description: |-
+                      workflowConcurrencyLimits defines per-workflow-name concurrency limits
+                      enforced globally across all replicas by the scheduler.
+                    items:
+                      description: |-
+                        NamedConcurrencyLimit defines a per-name concurrency limit for a specific
+                        workflow or activity name.
+                      properties:
+                        maxConcurrent:
+                          description: |-
+                            MaxConcurrent is the maximum number of concurrent invocations across all
+                            replicas.
+                          format: int32
+                          type: integer
+                        name:
+                          description: Name is the workflow or activity name to limit.
+                          type: string
+                      type: object
+                    type: array
                 type: object
             type: object
         type: object

--- a/dapr/internal/configure-pipeline/dependencies/crds.yaml
+++ b/dapr/internal/configure-pipeline/dependencies/crds.yaml
@@ -1,13 +1,20 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: components.dapr.io
   labels:
     app.kubernetes.io/part-of: "dapr"
 spec:
   group: dapr.io
+  names:
+    kind: Component
+    listKind: ComponentList
+    plural: components
+    singular: component
+  scope: Namespaced
   versions:
   - name: v1alpha1
     schema:
@@ -15,9 +22,11 @@ spec:
         description: Component describes an Dapr component type.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           auth:
             description: Auth represents authentication details for the component.
@@ -28,9 +37,12 @@ spec:
             - secretStore
             type: object
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -88,23 +100,13 @@ spec:
         type: object
     served: true
     storage: true
-  names:
-    kind: Component
-    plural: components
-    singular: component
-    categories:
-    - all
-    - dapr
-  scope: Namespaced
-
 
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: configurations.dapr.io
   labels:
     app.kubernetes.io/part-of: "dapr"
@@ -123,19 +125,24 @@ spec:
         description: Configuration describes an Dapr configuration setting.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: ConfigurationSpec is the spec for an configuration.
+            description: ConfigurationSpec is the spec for a configuration.
             properties:
               accessControl:
                 description: AccessControlSpec is the spec object in ConfigurationSpec.
@@ -184,9 +191,11 @@ spec:
                 description: APISpec describes the configuration for Dapr APIs.
                 properties:
                   allowed:
-                    description: List of allowed APIs. Can be used in conjunction with denied.
+                    description: List of allowed APIs. Can be used in conjunction
+                      with denied.
                     items:
-                      description: APIAccessRule describes an access rule for allowing or denying a Dapr API.
+                      description: APIAccessRule describes an access rule for allowing
+                        or denying a Dapr API.
                       properties:
                         name:
                           type: string
@@ -200,9 +209,11 @@ spec:
                       type: object
                     type: array
                   denied:
-                    description: List of denied APIs. Can be used in conjunction with allowed.
+                    description: List of denied APIs. Can be used in conjunction with
+                      allowed.
                     items:
-                      description: APIAccessRule describes an access rule for allowing or denying a Dapr API.
+                      description: APIAccessRule describes an access rule for allowing
+                        or denying a Dapr API.
                       properties:
                         name:
                           type: string
@@ -323,20 +334,20 @@ spec:
                     description: Configure API logging.
                     properties:
                       enabled:
-                        description: Default value for enabling API logging. Sidecars
-                          can always override this by setting `--enable-api-logging`
-                          to true or false explicitly. The default value is false.
+                        description: |-
+                          Default value for enabling API logging. Sidecars can always override this by setting `--enable-api-logging` to true or false explicitly.
+                          The default value is false.
                         type: boolean
                       obfuscateURLs:
-                        description: 'When enabled, obfuscates the values of URLs
-                          in HTTP API logs, logging the route name rather than the
-                          full path being invoked, which could contain PII. Default:
-                          false. This option has no effect if API logging is disabled.'
+                        description: |-
+                          When enabled, obfuscates the values of URLs in HTTP API logs, logging the route name rather than the full path being invoked, which could contain PII.
+                          Default: false.
+                          This option has no effect if API logging is disabled.
                         type: boolean
                       omitHealthChecks:
-                        description: 'If true, health checks are not reported in API
-                          logs. Default: false. This option has no effect if API logging
-                          is disabled.'
+                        description: |-
+                          If true, health checks are not reported in API logs. Default: false.
+                          This option has no effect if API logging is disabled.
                         type: boolean
                     type: object
                 type: object
@@ -351,20 +362,31 @@ spec:
                     description: MetricHTTP defines configuration for metrics for
                       the HTTP server
                     properties:
+                      excludeVerbs:
+                        description: If true (default is false) HTTP verbs (e.g.,
+                          GET, POST) are excluded from the metrics.
+                        type: boolean
                       increasedCardinality:
-                        description: 'If true, metrics for the HTTP server are collected
-                          with increased cardinality. The default is true in Dapr 1.13,
-                          but will be changed to false in 1.15+'
+                        description: |-
+                          If false, metrics for the HTTP server are collected with increased cardinality.
+                          The default is true in Dapr 1.13, but will be changed to false in 1.15+
                         type: boolean
                       pathMatching:
-                        description: PathMatching defines the path matching configuration for HTTP server metrics.
-                        type: array
                         items:
                           type: string
-                      excludeVerbs:
-                        description: If true (default is false) HTTP verbs (e.g., GET, POST) are excluded from the metrics.
-                        type: boolean
+                        type: array
                     type: object
+                  latencyDistributionBuckets:
+                    description: |-
+                      The LatencyDistributionBuckets variable specifies the latency distribution buckets (in milliseconds) used for
+                      histograms in the application. If this variable is not set or left empty, the application will default to using the standard histogram buckets.
+                      The default histogram latency buckets (in milliseconds) are as follows:
+                         1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500, 650, 800, 1,000, 2,000, 5,000, 10,000, 20,000, 50,000, 100,000.
+                    items:
+                      type: integer
+                    type: array
+                  recordErrorCodes:
+                    type: boolean
                   rules:
                     items:
                       description: MetricsRule defines configuration options for a
@@ -407,27 +429,31 @@ spec:
                     description: MetricHTTP defines configuration for metrics for
                       the HTTP server
                     properties:
+                      excludeVerbs:
+                        description: If true (default is false) HTTP verbs (e.g.,
+                          GET, POST) are excluded from the metrics.
+                        type: boolean
                       increasedCardinality:
-                        description: 'If true, metrics for the HTTP server are collected
-                          with increased cardinality. The default is true in Dapr 1.13,
-                          but will be changed to false in 1.14+'
+                        description: |-
+                          If false, metrics for the HTTP server are collected with increased cardinality.
+                          The default is true in Dapr 1.13, but will be changed to false in 1.15+
                         type: boolean
                       pathMatching:
-                        description: PathMatching defines the path matching configuration for HTTP server metrics.
-                        type: array
                         items:
                           type: string
-                      excludeVerbs:
-                          description: If true (default is false) HTTP verbs (e.g., GET, POST) are excluded from the metrics.
-                          type: boolean
+                        type: array
                     type: object
                   latencyDistributionBuckets:
-                    description: 'If a list of integers is specified, use
-                      these values for latency distribution buckets instead
-                      of the default values.'
+                    description: |-
+                      The LatencyDistributionBuckets variable specifies the latency distribution buckets (in milliseconds) used for
+                      histograms in the application. If this variable is not set or left empty, the application will default to using the standard histogram buckets.
+                      The default histogram latency buckets (in milliseconds) are as follows:
+                         1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500, 650, 800, 1,000, 2,000, 5,000, 10,000, 20,000, 50,000, 100,000.
                     items:
                       type: integer
                     type: array
+                  recordErrorCodes:
+                    type: boolean
                   rules:
                     items:
                       description: MetricsRule defines configuration options for a
@@ -471,10 +497,10 @@ spec:
                   sentryAddress:
                     type: string
                   tokenValidators:
-                    description: Additional token validators to use. When Dapr is
-                      running in Kubernetes mode, this is in addition to the built-in
-                      "kubernetes" validator. In self-hosted mode, enabling a custom
-                      validator will disable the built-in "insecure" validator.
+                    description: |-
+                      Additional token validators to use.
+                      When Dapr is running in Kubernetes mode, this is in addition to the built-in "kubernetes" validator.
+                      In self-hosted mode, enabling a custom validator will disable the built-in "insecure" validator.
                     items:
                       description: ValidatorSpec contains additional token validators
                         to use.
@@ -495,7 +521,9 @@ spec:
                   workloadCertTTL:
                     type: string
                 required:
+                - controlPlaneTrustDomain
                 - enabled
+                - sentryAddress
                 type: object
               nameResolution:
                 description: NameResolutionSpec is the spec for name resolution configuration.
@@ -548,9 +576,46 @@ spec:
                     properties:
                       endpointAddress:
                         type: string
+                      headers:
+                        description: |-
+                          Headers to add to the OTLP trace exporter request.
+                          Each header can contain plaintext values, reference secrets, or reference environment variables.
+                        items:
+                          description: NameValuePair is a name/value pair.
+                          properties:
+                            envRef:
+                              description: EnvRef is the name of an environmental
+                                variable to read the value from.
+                              type: string
+                            name:
+                              description: Name of the property.
+                              type: string
+                            secretKeyRef:
+                              description: SecretKeyRef is the reference of a value
+                                in a secret store component.
+                              properties:
+                                key:
+                                  description: Field in the secret.
+                                  type: string
+                                name:
+                                  description: Secret name.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            value:
+                              description: Value of the property, in plaintext.
+                              x-kubernetes-preserve-unknown-fields: true
+                          required:
+                          - name
+                          type: object
+                        type: array
                       isSecure:
                         type: boolean
                       protocol:
+                        type: string
+                      timeout:
+                        description: Timeout for the OTLP trace exporter request.
                         type: string
                     required:
                     - endpointAddress
@@ -573,21 +638,72 @@ spec:
                 - samplingRate
                 type: object
               wasm:
-                description: WasmSpec describes the security profile for all Dapr Wasm components.
+                description: WasmSpec describes the security profile for all Dapr
+                  Wasm components.
                 properties:
                   strictSandbox:
+                    description: |-
+                      Force enabling strict sandbox mode for all WASM components.
+                      When this is enabled, WASM components always run in strict mode regardless of their configuration.
+                      Strict mode enhances security of the WASM sandbox by limiting access to certain capabilities such as real-time clocks and random number generators.
                     type: boolean
+                type: object
+              workflow:
+                description: WorkflowSpec defines the configuration for Dapr workflows.
+                properties:
+                  maxConcurrentActivityInvocations:
+                    description: |-
+                      maxConcurrentActivityInvocations is the maximum number of concurrent activities that can be processed by a single Dapr instance.
+                      Attempted invocations beyond this will be queued until the number of concurrent invocations drops below this value.
+                      If omitted, no maximum will be enforced.
+                    format: int32
+                    type: integer
+                  maxConcurrentWorkflowInvocations:
+                    description: |-
+                      maxConcurrentWorkflowInvocations is the maximum number of concurrent workflow invocations that can be scheduled by a single Dapr instance.
+                      Attempted invocations beyond this will be queued until the number of concurrent invocations drops below this value.
+                      If omitted, no maximum will be enforced.
+                    format: int32
+                    type: integer
+                  stateRetentionPolicy:
+                    description: |-
+                      StateRetentionPolicy defines the retention configuration for workflow
+                      state once a workflow reaches a terminal state. If not set, workflow
+                      instances will not be automatically purged.
+                    properties:
+                      anyTerminal:
+                        description: |-
+                          AnyTerminal is the TTL for purging workflow instances that reach any
+                          terminal state.
+                        type: string
+                      completed:
+                        description: |-
+                          Completed is the TTL for purging workflow instances that reach the
+                          Completed terminal state.
+                        type: string
+                      failed:
+                        description: |-
+                          Failed is the TTL for purging workflow instances that reach the Failed
+                          terminal state.
+                        type: string
+                      terminated:
+                        description: |-
+                          Terminated is the TTL for purging workflow instances that reach the
+                          Terminated terminal state.
+                        type: string
+                    type: object
                 type: object
             type: object
         type: object
     served: true
     storage: true
 
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: httpendpoints.dapr.io
   labels:
     app.kubernetes.io/part-of: "dapr"
@@ -603,14 +719,16 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: HTTPEndpoint describes a Dapr HTTPEndpoint type for external
-          service invocation. This endpoint can be external to Dapr, or external to
-          the environment.
+        description: |-
+          HTTPEndpoint describes a Dapr HTTPEndpoint type for external service invocation.
+          This endpoint can be external to Dapr, or external to the environment.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           auth:
             description: Auth represents authentication details for the component.
@@ -621,9 +739,12 @@ spec:
             - secretStore
             type: object
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -750,20 +871,585 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.16.2
+  name: mcpservers.dapr.io
+  labels:
+    app.kubernetes.io/part-of: "dapr"
+spec:
+  group: dapr.io
+  names:
+    kind: MCPServer
+    listKind: MCPServerList
+    plural: mcpservers
+    singular: mcpserver
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MCPServer describes a Dapr MCPServer resource that declares a connection to
+          an MCP (Model Context Protocol) server for durable tool execution.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          scopes:
+            items:
+              type: string
+            type: array
+          spec:
+            description: MCPServerSpec is the full configuration for an MCP server
+              connection.
+            properties:
+              catalog:
+                description: |-
+                  Catalog holds user-facing governance metadata (display name, description,
+                  owner, tags, links). It is purely informational and not used at runtime.
+                properties:
+                  description:
+                    type: string
+                  displayName:
+                    type: string
+                  links:
+                    additionalProperties:
+                      type: string
+                    description: Links is a free-form map of named URLs (e.g. "docs",
+                      "runbook", "dashboard").
+                    type: object
+                  owner:
+                    description: MCPCatalogOwner identifies the team responsible for
+                      the MCP server.
+                    properties:
+                      contact:
+                        type: string
+                      team:
+                        type: string
+                    type: object
+                  tags:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              endpoint:
+                description: Endpoint describes the transport and target of the MCP
+                  server.
+                properties:
+                  sse:
+                    description: SSE holds configuration for the legacy SSE transport.
+                    properties:
+                      auth:
+                        description: Auth configures authentication for the MCP server
+                          connection.
+                        properties:
+                          oauth2:
+                            description: OAuth2 configures OAuth2 client credentials
+                              flow for the MCP server.
+                            properties:
+                              audience:
+                                type: string
+                              clientID:
+                                description: |-
+                                  ClientID is the OAuth2 client identifier sent to the token endpoint.
+                                  Required by RFC 6749 for the standard client_credentials flow (form parameter
+                                  or HTTP Basic username). May be left empty for non-standard flows (e.g. JWT-bearer
+                                  assertions or token endpoints that key solely on the client_secret). Client IDs
+                                  are typically public identifiers; use spec.headers with a secretKeyRef if your
+                                  environment requires sourcing the value from a secret store.
+                                type: string
+                              issuer:
+                                description: Issuer is the token endpoint of the authorization
+                                  server.
+                                minLength: 1
+                                type: string
+                              scopes:
+                                items:
+                                  type: string
+                                type: array
+                              secretKeyRef:
+                                description: SecretKeyRef references the client secret
+                                  in the configured secret store.
+                                properties:
+                                  key:
+                                    description: Field in the secret.
+                                    type: string
+                                  name:
+                                    description: Secret name.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - issuer
+                            type: object
+                          secretStore:
+                            description: |-
+                              SecretStore names the Dapr secret store used to resolve secretKeyRef entries
+                              in spec.endpoint.http.headers. auth.oauth2.secretKeyRef is resolved separately
+                              at call time by the MCP worker. Defaults to "kubernetes".
+                            type: string
+                          spiffe:
+                            description: |-
+                              SPIFFE configures workload identity JWT injection via Dapr's Sentry CA.
+                              No secret is required; Sentry issues the SVID automatically.
+                            properties:
+                              jwt:
+                                description: JWT configures how the SPIFFE SVID JWT
+                                  is attached to outbound requests.
+                                properties:
+                                  audience:
+                                    description: Audience is the intended audience
+                                      for the JWT (e.g. "mcp://payments").
+                                    minLength: 1
+                                    type: string
+                                  header:
+                                    description: Header is the HTTP header name to
+                                      inject the JWT into (e.g. "Authorization").
+                                    minLength: 1
+                                    type: string
+                                  headerValuePrefix:
+                                    description: HeaderValuePrefix is an optional
+                                      string prepended to the JWT value (e.g. "Bearer
+                                      ").
+                                    type: string
+                                required:
+                                - audience
+                                - header
+                                type: object
+                            type: object
+                        type: object
+                      headers:
+                        description: Headers are injected on all outbound HTTP requests
+                          to the MCP server.
+                        items:
+                          description: NameValuePair is a name/value pair.
+                          properties:
+                            envRef:
+                              description: EnvRef is the name of an environmental
+                                variable to read the value from.
+                              type: string
+                            name:
+                              description: Name of the property.
+                              type: string
+                            secretKeyRef:
+                              description: SecretKeyRef is the reference of a value
+                                in a secret store component.
+                              properties:
+                                key:
+                                  description: Field in the secret.
+                                  type: string
+                                name:
+                                  description: Secret name.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            value:
+                              description: Value of the property, in plaintext.
+                              x-kubernetes-preserve-unknown-fields: true
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      protocolVersion:
+                        description: |-
+                          ProtocolVersion pins the MCP spec version the server implements,
+                          using the date-based format defined by the MCP specification (e.g. "2025-06-18").
+                          When unset, the go-sdk negotiates the latest version supported by both sides.
+                        type: string
+                      timeout:
+                        description: Timeout is the per-call deadline for MCP requests.
+                        type: string
+                      url:
+                        description: URL is the endpoint URL of the MCP server.
+                        minLength: 1
+                        type: string
+                    required:
+                    - url
+                    type: object
+                  stdio:
+                    description: Stdio holds configuration for the stdio subprocess
+                      transport.
+                    properties:
+                      args:
+                        items:
+                          type: string
+                        type: array
+                      command:
+                        description: Command is the executable to run.
+                        minLength: 1
+                        type: string
+                      env:
+                        description: |-
+                          Env are environment variables injected into the subprocess.
+                          Supports plain value, secretKeyRef, and envRef.
+                        items:
+                          description: NameValuePair is a name/value pair.
+                          properties:
+                            envRef:
+                              description: EnvRef is the name of an environmental
+                                variable to read the value from.
+                              type: string
+                            name:
+                              description: Name of the property.
+                              type: string
+                            secretKeyRef:
+                              description: SecretKeyRef is the reference of a value
+                                in a secret store component.
+                              properties:
+                                key:
+                                  description: Field in the secret.
+                                  type: string
+                                name:
+                                  description: Secret name.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            value:
+                              description: Value of the property, in plaintext.
+                              x-kubernetes-preserve-unknown-fields: true
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    required:
+                    - command
+                    type: object
+                  streamableHTTP:
+                    description: StreamableHTTP holds configuration for the streamable_http
+                      transport.
+                    properties:
+                      auth:
+                        description: Auth configures authentication for the MCP server
+                          connection.
+                        properties:
+                          oauth2:
+                            description: OAuth2 configures OAuth2 client credentials
+                              flow for the MCP server.
+                            properties:
+                              audience:
+                                type: string
+                              clientID:
+                                description: |-
+                                  ClientID is the OAuth2 client identifier sent to the token endpoint.
+                                  Required by RFC 6749 for the standard client_credentials flow (form parameter
+                                  or HTTP Basic username). May be left empty for non-standard flows (e.g. JWT-bearer
+                                  assertions or token endpoints that key solely on the client_secret). Client IDs
+                                  are typically public identifiers; use spec.headers with a secretKeyRef if your
+                                  environment requires sourcing the value from a secret store.
+                                type: string
+                              issuer:
+                                description: Issuer is the token endpoint of the authorization
+                                  server.
+                                minLength: 1
+                                type: string
+                              scopes:
+                                items:
+                                  type: string
+                                type: array
+                              secretKeyRef:
+                                description: SecretKeyRef references the client secret
+                                  in the configured secret store.
+                                properties:
+                                  key:
+                                    description: Field in the secret.
+                                    type: string
+                                  name:
+                                    description: Secret name.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - issuer
+                            type: object
+                          secretStore:
+                            description: |-
+                              SecretStore names the Dapr secret store used to resolve secretKeyRef entries
+                              in spec.endpoint.http.headers. auth.oauth2.secretKeyRef is resolved separately
+                              at call time by the MCP worker. Defaults to "kubernetes".
+                            type: string
+                          spiffe:
+                            description: |-
+                              SPIFFE configures workload identity JWT injection via Dapr's Sentry CA.
+                              No secret is required; Sentry issues the SVID automatically.
+                            properties:
+                              jwt:
+                                description: JWT configures how the SPIFFE SVID JWT
+                                  is attached to outbound requests.
+                                properties:
+                                  audience:
+                                    description: Audience is the intended audience
+                                      for the JWT (e.g. "mcp://payments").
+                                    minLength: 1
+                                    type: string
+                                  header:
+                                    description: Header is the HTTP header name to
+                                      inject the JWT into (e.g. "Authorization").
+                                    minLength: 1
+                                    type: string
+                                  headerValuePrefix:
+                                    description: HeaderValuePrefix is an optional
+                                      string prepended to the JWT value (e.g. "Bearer
+                                      ").
+                                    type: string
+                                required:
+                                - audience
+                                - header
+                                type: object
+                            type: object
+                        type: object
+                      headers:
+                        description: |-
+                          Headers are injected on all outbound HTTP requests to the MCP server.
+                          Each entry follows the same NameValuePair contract used by HTTPEndpoint:
+                          plain value, secretKeyRef, or envRef. Secret resolution uses auth.secretStore.
+                        items:
+                          description: NameValuePair is a name/value pair.
+                          properties:
+                            envRef:
+                              description: EnvRef is the name of an environmental
+                                variable to read the value from.
+                              type: string
+                            name:
+                              description: Name of the property.
+                              type: string
+                            secretKeyRef:
+                              description: SecretKeyRef is the reference of a value
+                                in a secret store component.
+                              properties:
+                                key:
+                                  description: Field in the secret.
+                                  type: string
+                                name:
+                                  description: Secret name.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            value:
+                              description: Value of the property, in plaintext.
+                              x-kubernetes-preserve-unknown-fields: true
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      protocolVersion:
+                        description: |-
+                          ProtocolVersion pins the MCP spec version the server implements,
+                          using the date-based format defined by the MCP specification (e.g. "2025-06-18").
+                          When unset, the go-sdk negotiates the latest version supported by both sides.
+                        type: string
+                      timeout:
+                        description: Timeout is the per-call deadline for MCP requests.
+                        type: string
+                      url:
+                        description: URL is the endpoint URL of the MCP server.
+                        minLength: 1
+                        type: string
+                    required:
+                    - url
+                    type: object
+                type: object
+                x-kubernetes-validations:
+                - message: exactly one of streamableHTTP, sse, or stdio must be set
+                  rule: '(has(self.streamableHTTP) ? 1 : 0) + (has(self.sse) ? 1 :
+                    0) + (has(self.stdio) ? 1 : 0) == 1'
+              ignoreErrors:
+                description: |-
+                  IgnoreErrors, when true, allows daprd to continue running if validation
+                  or secret resolution fails for this MCPServer. When false (default),
+                  such failures cause daprd to exit gracefully.
+                type: boolean
+              middleware:
+                description: Middleware defines optional workflow hooks invoked around
+                  each tool call.
+                properties:
+                  afterCallTool:
+                    description: |-
+                      AfterCallTool hooks are invoked in order after each CallTool.
+                      Receives {mcpServer, toolName, arguments, result} as input.
+                      Errors fail the workflow — after-hooks act as authorization gates.
+                    items:
+                      description: |-
+                        MutatingMCPMiddlewareHook extends MCPMiddlewareHook with the ability to
+                        replace the data flowing through the pipeline when Mutate is true.
+                      properties:
+                        mutate:
+                          description: |-
+                            Mutate, when true, causes the hook's return value to replace the data
+                            flowing through the pipeline:
+                              - beforeCallTool: replaces the arguments sent to the tool call
+                                (e.g. redact PII, inject defaults).
+                              - afterCallTool / afterListTools: replaces the result returned to the caller.
+                            When false (default), the hook validates/observes only — its output is discarded.
+                          type: boolean
+                        workflow:
+                          description: Workflow is the Dapr workflow to invoke as
+                            the hook.
+                          properties:
+                            appID:
+                              description: |-
+                                AppID targets the workflow on a remote Dapr app via service invocation.
+                                When unset, the workflow is invoked locally.
+                              type: string
+                            workflowName:
+                              description: WorkflowName is the name of the workflow
+                                to invoke.
+                              minLength: 1
+                              type: string
+                          required:
+                          - workflowName
+                          type: object
+                      required:
+                      - workflow
+                      type: object
+                    type: array
+                  afterListTools:
+                    description: |-
+                      AfterListTools hooks are invoked in order after each ListTools.
+                      Receives {mcpServer, result} as input.
+                      Errors are logged but do not affect the result.
+                    items:
+                      description: |-
+                        MutatingMCPMiddlewareHook extends MCPMiddlewareHook with the ability to
+                        replace the data flowing through the pipeline when Mutate is true.
+                      properties:
+                        mutate:
+                          description: |-
+                            Mutate, when true, causes the hook's return value to replace the data
+                            flowing through the pipeline:
+                              - beforeCallTool: replaces the arguments sent to the tool call
+                                (e.g. redact PII, inject defaults).
+                              - afterCallTool / afterListTools: replaces the result returned to the caller.
+                            When false (default), the hook validates/observes only — its output is discarded.
+                          type: boolean
+                        workflow:
+                          description: Workflow is the Dapr workflow to invoke as
+                            the hook.
+                          properties:
+                            appID:
+                              description: |-
+                                AppID targets the workflow on a remote Dapr app via service invocation.
+                                When unset, the workflow is invoked locally.
+                              type: string
+                            workflowName:
+                              description: WorkflowName is the name of the workflow
+                                to invoke.
+                              minLength: 1
+                              type: string
+                          required:
+                          - workflowName
+                          type: object
+                      required:
+                      - workflow
+                      type: object
+                    type: array
+                  beforeCallTool:
+                    description: |-
+                      BeforeCallTool hooks are invoked in order before each CallTool.
+                      Receives {mcpServer, toolName, arguments} as input.
+                      If any hook returns an error, the chain stops and the workflow completes
+                      with CallToolResult{isError: true} so the agent/LLM can self-correct.
+                    items:
+                      description: |-
+                        MutatingMCPMiddlewareHook extends MCPMiddlewareHook with the ability to
+                        replace the data flowing through the pipeline when Mutate is true.
+                      properties:
+                        mutate:
+                          description: |-
+                            Mutate, when true, causes the hook's return value to replace the data
+                            flowing through the pipeline:
+                              - beforeCallTool: replaces the arguments sent to the tool call
+                                (e.g. redact PII, inject defaults).
+                              - afterCallTool / afterListTools: replaces the result returned to the caller.
+                            When false (default), the hook validates/observes only — its output is discarded.
+                          type: boolean
+                        workflow:
+                          description: Workflow is the Dapr workflow to invoke as
+                            the hook.
+                          properties:
+                            appID:
+                              description: |-
+                                AppID targets the workflow on a remote Dapr app via service invocation.
+                                When unset, the workflow is invoked locally.
+                              type: string
+                            workflowName:
+                              description: WorkflowName is the name of the workflow
+                                to invoke.
+                              minLength: 1
+                              type: string
+                          required:
+                          - workflowName
+                          type: object
+                      required:
+                      - workflow
+                      type: object
+                    type: array
+                  beforeListTools:
+                    description: |-
+                      BeforeListTools hooks are invoked in order before each ListTools.
+                      Receives {mcpServer} as input.
+                      If any hook returns an error, the chain stops and the error is returned.
+                    items:
+                      description: MCPMiddlewareHook is a single middleware hook.
+                      properties:
+                        workflow:
+                          description: Workflow is the Dapr workflow to invoke as
+                            the hook.
+                          properties:
+                            appID:
+                              description: |-
+                                AppID targets the workflow on a remote Dapr app via service invocation.
+                                When unset, the workflow is invoked locally.
+                              type: string
+                            workflowName:
+                              description: WorkflowName is the name of the workflow
+                                to invoke.
+                              minLength: 1
+                              type: string
+                          required:
+                          - workflowName
+                          type: object
+                      required:
+                      - workflow
+                      type: object
+                    type: array
+                type: object
+            required:
+            - endpoint
+            type: object
+        type: object
+    served: true
+    storage: true
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: resiliencies.dapr.io
   labels:
     app.kubernetes.io/part-of: "dapr"
@@ -774,8 +1460,6 @@ spec:
     listKind: ResiliencyList
     plural: resiliencies
     singular: resiliency
-    categories:
-    - dapr
   scope: Namespaced
   versions:
   - name: v1alpha1
@@ -783,10 +1467,19 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -816,6 +1509,19 @@ spec:
                       properties:
                         duration:
                           type: string
+                        matching:
+                          description: RetryMatching represents the rules to trigger
+                            retry in specific scenarios.
+                          properties:
+                            gRPCStatusCodes:
+                              description: GRPCStatusCodes represents gRPC status
+                                codes to be retried.
+                              type: string
+                            httpStatusCodes:
+                              description: HTTPStatusCodes represents HTTP status
+                                codes to be retried.
+                              type: string
+                          type: object
                         maxInterval:
                           type: string
                         maxRetries:
@@ -891,12 +1597,12 @@ spec:
     served: true
     storage: true
 
-
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: subscriptions.dapr.io
   labels:
     app.kubernetes.io/part-of: "dapr"
@@ -914,6 +1620,12 @@ spec:
       conversionReviewVersions:
       - v1
       - v2alpha1
+  names:
+    kind: Subscription
+    listKind: SubscriptionList
+    plural: subscriptions
+    singular: subscription
+  scope: Namespaced
   versions:
   - name: v1alpha1
     schema:
@@ -921,14 +1633,19 @@ spec:
         description: Subscription describes an pub/sub event subscription.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -939,30 +1656,33 @@ spec:
           spec:
             description: SubscriptionSpec is the spec for an event subscription.
             properties:
+              bulkSubscribe:
+                description: BulkSubscribe encapsulates the bulk subscription configuration
+                  for a topic.
+                properties:
+                  enabled:
+                    type: boolean
+                  maxAwaitDurationMs:
+                    format: int32
+                    type: integer
+                  maxMessagesCount:
+                    format: int32
+                    type: integer
+                required:
+                - enabled
+                type: object
+              deadLetterTopic:
+                type: string
+              metadata:
+                additionalProperties:
+                  type: string
+                type: object
               pubsubname:
                 type: string
               route:
                 type: string
               topic:
                 type: string
-              deadLetterTopic:
-                type: string
-              bulkSubscribe:
-                description: Represents bulk subscribe properties
-                properties:
-                  enabled:
-                    type: boolean
-                  maxMessagesCount:
-                    type: integer
-                  maxAwaitDurationMs:
-                    type: integer
-                required:
-                  - enabled
-                type: object
-              metadata:
-                additionalProperties:
-                  type: string
-                type: object
             required:
             - pubsubname
             - route
@@ -977,14 +1697,19 @@ spec:
         description: Subscription describes an pub/sub event subscription.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -995,6 +1720,24 @@ spec:
           spec:
             description: SubscriptionSpec is the spec for an event subscription.
             properties:
+              bulkSubscribe:
+                description: The option to enable bulk subscription for this topic.
+                properties:
+                  enabled:
+                    type: boolean
+                  maxAwaitDurationMs:
+                    format: int32
+                    type: integer
+                  maxMessagesCount:
+                    format: int32
+                    type: integer
+                required:
+                - enabled
+                type: object
+              deadLetterTopic:
+                description: The optional dead letter queue for this topic to send
+                  events to.
+                type: string
               metadata:
                 additionalProperties:
                   type: string
@@ -1007,20 +1750,22 @@ spec:
                 description: The Routes configuration for this topic.
                 properties:
                   default:
+                    description: The default path for this topic.
                     type: string
                   rules:
                     description: The list of rules for this topic.
                     items:
-                      description: Rule is used to specify the condition for sending
+                      description: |-
+                        Rule is used to specify the condition for sending
                         a message to a specific path.
                       properties:
                         match:
-                          description: The optional CEL expression used to match the
-                            event. If the match is not specified, then the route is
-                            considered the default. The rules are tested in the order
-                            specified, so they should be define from most-to-least
-                            specific. The default route should appear last in the
-                            list.
+                          description: |-
+                            The optional CEL expression used to match the event.
+                            If the match is not specified, then the route is considered
+                            the default. The rules are tested in the order specified,
+                            so they should be define from most-to-least specific.
+                            The default route should appear last in the list.
                           type: string
                         path:
                           description: The path for events that match this rule.
@@ -1034,21 +1779,6 @@ spec:
               topic:
                 description: The topic name to subscribe to.
                 type: string
-              deadLetterTopic:
-                description: The optional dead letter queue for this topic to send events to.
-                type: string
-              bulkSubscribe:
-                description: Represents bulk subscribe properties
-                properties:
-                  enabled:
-                    type: boolean
-                  maxMessagesCount:
-                    type: integer
-                  maxAwaitDurationMs:
-                    type: integer
-                required:
-                  - enabled
-                type: object
             required:
             - pubsubname
             - routes
@@ -1057,13 +1787,146 @@ spec:
         type: object
     served: true
     storage: true
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: workflowaccesspolicies.dapr.io
+  labels:
+    app.kubernetes.io/part-of: "dapr"
+spec:
+  group: dapr.io
   names:
-    kind: Subscription
-    listKind: SubscriptionList
-    plural: subscriptions
-    singular: subscription
-    categories:
-    - all
-    - dapr
+    kind: WorkflowAccessPolicy
+    listKind: WorkflowAccessPolicyList
+    plural: workflowaccesspolicies
+    singular: workflowaccesspolicy
   scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          WorkflowAccessPolicy controls which app IDs are permitted to schedule
+          specific workflows and activities on a target application.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          scopes:
+            items:
+              type: string
+            type: array
+          spec:
+            description: WorkflowAccessPolicySpec defines the desired state of WorkflowAccessPolicy.
+            properties:
+              rules:
+                description: Rules defines the allow-list of which callers can perform
+                  which operations.
+                items:
+                  description: |-
+                    WorkflowAccessPolicyRule grants the listed callers access to the listed
+                    workflows and/or activities. Presence of a matching rule grants access; if
+                    no rule matches, the call is denied. At least one of workflows or
+                    activities must be set.
+                  properties:
+                    activities:
+                      description: Activities are the activity rules that the matched
+                        callers are allowed.
+                      items:
+                        description: |-
+                          ActivityRule grants the matched callers access to schedule the activity
+                          whose name matches Name (exact or glob). Activities only have one
+                          operation (schedule).
+                        properties:
+                          name:
+                            description: Name is the exact name or glob pattern for
+                              the activity.
+                            minLength: 1
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    callers:
+                      description: Callers that this rule applies to.
+                      items:
+                        description: WorkflowCaller identifies a calling application.
+                        properties:
+                          appID:
+                            description: AppID is the Dapr app ID of the caller.
+                            minLength: 1
+                            type: string
+                        required:
+                        - appID
+                        type: object
+                      minItems: 1
+                      type: array
+                    workflows:
+                      description: Workflows are the workflow rules that the matched
+                        callers are allowed.
+                      items:
+                        description: |-
+                          WorkflowRule grants the matched callers access to the listed operations on
+                          workflows whose name matches Name (exact or glob).
+                        properties:
+                          name:
+                            description: Name is the exact name or glob pattern for
+                              the workflow.
+                            minLength: 1
+                            type: string
+                          operations:
+                            description: Operations is the set of operations this
+                              rule applies to.
+                            items:
+                              description: WorkflowOperation is the specific workflow
+                                operation being controlled.
+                              enum:
+                              - schedule
+                              - terminate
+                              - raise
+                              - pause
+                              - resume
+                              - purge
+                              - get
+                              - rerun
+                              type: string
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: set
+                        required:
+                        - name
+                        - operations
+                        type: object
+                      type: array
+                  required:
+                  - callers
+                  type: object
+                  x-kubernetes-validations:
+                  - message: at least one of workflows or activities must contain
+                      a rule
+                    rule: (has(self.workflows) && size(self.workflows) > 0) || (has(self.activities)
+                      && size(self.activities) > 0)
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
 

--- a/dapr/internal/configure-pipeline/dependencies/dapr.yaml
+++ b/dapr/internal/configure-pipeline/dependencies/dapr.yaml
@@ -3,10 +3,10 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-injector
   namespace: dapr-system
 ---
@@ -15,10 +15,10 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-operator
   namespace: dapr-system
 ---
@@ -27,10 +27,10 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-placement
   namespace: dapr-system
 ---
@@ -39,10 +39,10 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-scheduler
   namespace: dapr-system
 ---
@@ -51,10 +51,10 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-sentry
   namespace: dapr-system
 ---
@@ -63,10 +63,10 @@ kind: Role
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-injector
   namespace: dapr-system
 rules:
@@ -96,10 +96,10 @@ kind: Role
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-operator
   namespace: dapr-system
 rules:
@@ -148,10 +148,10 @@ kind: Role
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-sentry
   namespace: dapr-system
 rules:
@@ -190,10 +190,10 @@ kind: Role
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: secret-reader
   namespace: dapr-system
 rules:
@@ -209,10 +209,10 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-injector
 rules:
 - apiGroups:
@@ -243,10 +243,10 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-operator-admin
 rules:
 - apiGroups:
@@ -328,6 +328,8 @@ rules:
   - subscriptions
   - resiliencies
   - httpendpoints
+  - mcpservers
+  - workflowaccesspolicies
   verbs:
   - get
   - list
@@ -338,10 +340,10 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-placement
 rules: []
 ---
@@ -350,22 +352,30 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-scheduler
-rules: []
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-sentry
 rules:
 - apiGroups:
@@ -396,10 +406,10 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-injector
   namespace: dapr-system
 roleRef:
@@ -416,10 +426,10 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-operator
   namespace: dapr-system
 roleRef:
@@ -436,10 +446,10 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-secret-reader
   namespace: dapr-system
 roleRef:
@@ -456,10 +466,10 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-sentry
   namespace: dapr-system
 roleRef:
@@ -476,10 +486,10 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-injector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -495,10 +505,10 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-operator-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -514,10 +524,10 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-placement
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -533,10 +543,10 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-scheduler
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -552,10 +562,10 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-sentry
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -572,10 +582,10 @@ metadata:
   labels:
     app: dapr-sentry
     app.kubernetes.io/component: sentry
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-trust-bundle
   namespace: dapr-system
 ---
@@ -585,10 +595,10 @@ metadata:
   labels:
     app: dapr-sentry
     app.kubernetes.io/component: sentry
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-trust-bundle
   namespace: dapr-system
 ---
@@ -601,10 +611,10 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app.kubernetes.io/component: operator
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-api
   namespace: dapr-system
 spec:
@@ -635,10 +645,10 @@ metadata:
   labels:
     app: dapr-placement-server
     app.kubernetes.io/component: placement
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-placement-server
   namespace: dapr-system
 spec:
@@ -666,10 +676,10 @@ metadata:
   labels:
     app: dapr-scheduler-server
     app.kubernetes.io/component: scheduler
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-scheduler-server
   namespace: dapr-system
 spec:
@@ -679,8 +689,6 @@ spec:
     port: 50006
   - name: etcd-client
     port: 2379
-  - name: etcd-httpclient
-    port: 2330
   - name: etcd-peer
     port: 2380
   - name: metrics
@@ -699,11 +707,45 @@ metadata:
     prometheus.io/port: "9090"
     prometheus.io/scrape: "true"
   labels:
-    app.kubernetes.io/component: sentry
-    app.kubernetes.io/managed-by: helm
+    app: dapr-scheduler-server
+    app.kubernetes.io/component: scheduler
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
+  name: dapr-scheduler-server-a
+  namespace: dapr-system
+spec:
+  ports:
+  - name: api
+    port: 443
+    targetPort: 50006
+  - name: etcd-client
+    port: 2379
+  - name: etcd-peer
+    port: 2380
+  - name: metrics
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
+  publishNotReadyAddresses: true
+  selector:
+    app: dapr-scheduler-server
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/path: /
+    prometheus.io/port: "9090"
+    prometheus.io/scrape: "true"
+  labels:
+    app.kubernetes.io/component: sentry
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: dapr
+    app.kubernetes.io/part-of: dapr
+    app.kubernetes.io/version: 1.18.0
   name: dapr-sentry
   namespace: dapr-system
 spec:
@@ -729,10 +771,10 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app.kubernetes.io/component: sidecar-injector
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-sidecar-injector
   namespace: dapr-system
 spec:
@@ -754,10 +796,10 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: operator
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-webhook
   namespace: dapr-system
 spec:
@@ -775,10 +817,10 @@ metadata:
   labels:
     app: dapr-operator
     app.kubernetes.io/component: operator
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-operator
   namespace: dapr-system
 spec:
@@ -796,10 +838,10 @@ spec:
       labels:
         app: dapr-operator
         app.kubernetes.io/component: operator
-        app.kubernetes.io/managed-by: helm
+        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: dapr
         app.kubernetes.io/part-of: dapr
-        app.kubernetes.io/version: 1.14.1
+        app.kubernetes.io/version: 1.18.0
     spec:
       affinity:
         nodeAffinity:
@@ -830,15 +872,15 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/dapr/operator:1.14.1
+        image: ghcr.io/dapr/operator:1.18.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
           httpGet:
             path: /healthz
             port: 8080
-          initialDelaySeconds: 3
-          periodSeconds: 3
+          initialDelaySeconds: 180
+          periodSeconds: 10
         name: dapr-operator
         ports:
         - containerPort: 6500
@@ -846,14 +888,15 @@ spec:
           name: metrics
           protocol: TCP
         readinessProbe:
-          failureThreshold: 5
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 8080
-          initialDelaySeconds: 3
-          periodSeconds: 3
+          initialDelaySeconds: 1
+          periodSeconds: 1
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           capabilities:
             drop:
             - ALL
@@ -872,7 +915,7 @@ spec:
       volumes:
       - emptyDir:
           medium: Memory
-          sizeLimit: 2Mi
+          sizeLimit: 64Mi
         name: dapr-operator-tmp
       - configMap:
           name: dapr-trust-bundle
@@ -891,10 +934,10 @@ metadata:
   labels:
     app: dapr-sentry
     app.kubernetes.io/component: sentry
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-sentry
   namespace: dapr-system
 spec:
@@ -912,10 +955,10 @@ spec:
       labels:
         app: dapr-sentry
         app.kubernetes.io/component: sentry
-        app.kubernetes.io/managed-by: helm
+        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: dapr
         app.kubernetes.io/part-of: dapr
-        app.kubernetes.io/version: 1.14.1
+        app.kubernetes.io/version: 1.18.0
     spec:
       affinity:
         nodeAffinity:
@@ -928,6 +971,8 @@ spec:
                 - linux
       containers:
       - args:
+        - --mode
+        - kubernetes
         - --log-level
         - info
         - --enable-metrics
@@ -942,15 +987,15 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/dapr/sentry:1.14.1
+        image: ghcr.io/dapr/sentry:1.18.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
           httpGet:
             path: /healthz
             port: 8080
-          initialDelaySeconds: 3
-          periodSeconds: 3
+          initialDelaySeconds: 180
+          periodSeconds: 10
         name: dapr-sentry
         ports:
         - containerPort: 50001
@@ -958,14 +1003,15 @@ spec:
           name: metrics
           protocol: TCP
         readinessProbe:
-          failureThreshold: 5
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 8080
-          initialDelaySeconds: 3
-          periodSeconds: 3
+          initialDelaySeconds: 1
+          periodSeconds: 1
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           capabilities:
             drop:
             - ALL
@@ -987,10 +1033,10 @@ metadata:
   labels:
     app: dapr-sidecar-injector
     app.kubernetes.io/component: sidecar-injector
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-sidecar-injector
   namespace: dapr-system
 spec:
@@ -1008,10 +1054,10 @@ spec:
       labels:
         app: dapr-sidecar-injector
         app.kubernetes.io/component: sidecar-injector
-        app.kubernetes.io/managed-by: helm
+        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: dapr
         app.kubernetes.io/part-of: dapr
-        app.kubernetes.io/version: 1.14.1
+        app.kubernetes.io/version: 1.18.0
     spec:
       affinity:
         nodeAffinity:
@@ -1031,6 +1077,7 @@ spec:
         - "9090"
         - --healthz-port
         - "8080"
+        - --scheduler-enabled=true
         command:
         - /injector
         env:
@@ -1043,7 +1090,7 @@ spec:
         - name: KUBE_CLUSTER_DOMAIN
           value: cluster.local
         - name: SIDECAR_IMAGE
-          value: ghcr.io/dapr/daprd:1.14.1
+          value: ghcr.io/dapr/daprd:1.18.0
         - name: SIDECAR_IMAGE_PULL_POLICY
           value: IfNotPresent
         - name: SIDECAR_RUN_AS_NON_ROOT
@@ -1054,6 +1101,8 @@ spec:
           value: "false"
         - name: SIDECAR_READ_ONLY_ROOT_FILESYSTEM
           value: "true"
+        - name: NATIVE_SIDECAR_ENABLED
+          value: "false"
         - name: NAMESPACE
           valueFrom:
             fieldRef:
@@ -1066,15 +1115,15 @@ spec:
           value: placement
         - name: ACTORS_SERVICE_ADDRESS
           value: dapr-placement-server:50005
-        image: ghcr.io/dapr/injector:1.14.1
+        image: ghcr.io/dapr/injector:1.18.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
           httpGet:
             path: /healthz
             port: 8080
-          initialDelaySeconds: 3
-          periodSeconds: 3
+          initialDelaySeconds: 180
+          periodSeconds: 10
         name: dapr-sidecar-injector
         ports:
         - containerPort: 4000
@@ -1084,14 +1133,15 @@ spec:
           name: metrics
           protocol: TCP
         readinessProbe:
-          failureThreshold: 5
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 8080
-          initialDelaySeconds: 3
-          periodSeconds: 3
+          initialDelaySeconds: 1
+          periodSeconds: 1
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           capabilities:
             drop:
             - ALL
@@ -1123,10 +1173,10 @@ metadata:
   labels:
     app: dapr-placement-server
     app.kubernetes.io/component: placement
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-placement-server
   namespace: dapr-system
 spec:
@@ -1146,10 +1196,10 @@ spec:
       labels:
         app: dapr-placement-server
         app.kubernetes.io/component: placement
-        app.kubernetes.io/managed-by: helm
+        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: dapr
         app.kubernetes.io/part-of: dapr
-        app.kubernetes.io/version: 1.14.1
+        app.kubernetes.io/version: 1.18.0
     spec:
       affinity:
         nodeAffinity:
@@ -1164,13 +1214,14 @@ spec:
       - args:
         - --log-level
         - info
+        - --replicationFactor=100
+        - --max-api-level=10
+        - --min-api-level=0
+        - --keepalive-time=2s
+        - --keepalive-timeout=3s
+        - --disseminate-timeout=8s
+        - --disseminate-coalesce-window=0s
         - --enable-metrics
-        - --replicationFactor
-        - "100"
-        - --max-api-level
-        - "10"
-        - --min-api-level
-        - "0"
         - --metrics-port
         - "9090"
         - --tls-enabled
@@ -1189,15 +1240,15 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/dapr/placement:1.14.1
+        image: ghcr.io/dapr/placement:1.18.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
           httpGet:
             path: /healthz
             port: 8080
-          initialDelaySeconds: 10
-          periodSeconds: 3
+          initialDelaySeconds: 180
+          periodSeconds: 10
         name: dapr-placement-server
         ports:
         - containerPort: 50005
@@ -1208,25 +1259,28 @@ spec:
           name: metrics
           protocol: TCP
         readinessProbe:
-          failureThreshold: 5
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 8080
-          initialDelaySeconds: 3
-          periodSeconds: 3
+          initialDelaySeconds: 1
+          periodSeconds: 1
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           capabilities:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsUser: 0
+          runAsNonRoot: true
         volumeMounts:
         - mountPath: /var/run/secrets/dapr.io/tls
           name: dapr-trust-bundle
           readOnly: true
         - mountPath: /var/run/secrets/dapr.io/sentrytoken
           name: dapr-identity-token
+      securityContext:
+        fsGroup: 65532
       serviceAccountName: dapr-placement
       volumes:
       - configMap:
@@ -1246,15 +1300,15 @@ metadata:
   labels:
     app: dapr-scheduler-server
     app.kubernetes.io/component: scheduler
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-scheduler-server
   namespace: dapr-system
 spec:
   podManagementPolicy: Parallel
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app: dapr-scheduler-server
@@ -1269,10 +1323,10 @@ spec:
       labels:
         app: dapr-scheduler-server
         app.kubernetes.io/component: scheduler
-        app.kubernetes.io/managed-by: helm
+        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: dapr
         app.kubernetes.io/part-of: dapr
-        app.kubernetes.io/version: 1.14.1
+        app.kubernetes.io/version: 1.18.0
     spec:
       affinity:
         nodeAffinity:
@@ -1283,33 +1337,51 @@ spec:
                 operator: In
                 values:
                 - linux
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - dapr-scheduler-server
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - args:
         - --listen-address=0.0.0.0
         - --id
         - $(SCHEDULER_ID)
-        - --replica-count
-        - "1"
-        - --initial-cluster
-        - dapr-scheduler-server-0=http://dapr-scheduler-server-0.dapr-scheduler-server.dapr-system.svc.cluster.local:2380
-        - --etcd-client-ports
-        - dapr-scheduler-server-0=2379
-        - --etcd-client-http-ports
-        - dapr-scheduler-server-0=2330
+        - --etcd-initial-cluster
+        - dapr-scheduler-server-0=https://dapr-scheduler-server-0.dapr-scheduler-server.dapr-system.svc.cluster.local:2380,dapr-scheduler-server-1=https://dapr-scheduler-server-1.dapr-scheduler-server.dapr-system.svc.cluster.local:2380,dapr-scheduler-server-2=https://dapr-scheduler-server-2.dapr-scheduler-server.dapr-system.svc.cluster.local:2380
+        - --etcd-embed=true
         - --log-level
         - info
         - --enable-metrics
         - --metrics-port
         - "9090"
+        - --etcd-client-port
+        - "2379"
         - --etcd-data-dir=/var/run/data/dapr-scheduler/dapr-system/$(SCHEDULER_ID)
-        - --etcd-space-quota=2147483648
-        - --etcd-compaction-mode=periodic
-        - --etcd-compaction-retention=24h
+        - --etcd-space-quota=9.2E
+        - --etcd-compaction-mode=revision
+        - --etcd-compaction-retention=1000000
+        - --etcd-snapshot-count=100000
+        - --etcd-max-snapshots=10
+        - --etcd-max-wals=10
+        - --etcd-backend-batch-limit=10000
+        - --etcd-backend-batch-interval=100ms
+        - --etcd-max-txn-ops=10000
+        - --etcd-experimental-bootstrap-defrag-threshold-megabytes=100
+        - --etcd-initial-election-tick-advance=false
+        - --etcd-metrics=basic
         - --tls-enabled
         - --trust-domain=cluster.local
         - --trust-anchors-file=/var/run/secrets/dapr.io/tls/ca.crt
         - --sentry-address=dapr-sentry.dapr-system.svc.cluster.local:443
         - --mode=kubernetes
+        - --workers=2048
         command:
         - /scheduler
         env:
@@ -1325,46 +1397,46 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: ghcr.io/dapr/scheduler:1.14.1
+        image: ghcr.io/dapr/scheduler:1.18.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
           httpGet:
             path: /healthz
             port: 8080
-          initialDelaySeconds: 10
-          periodSeconds: 3
+          initialDelaySeconds: 180
+          periodSeconds: 10
         name: dapr-scheduler-server
         ports:
         - containerPort: 50006
-          name: api
         - containerPort: 2379
           name: etcd-client
-        - containerPort: 2330
-          name: etcd-httpclient
         - containerPort: 2380
           name: etcd-peer
         - containerPort: 9090
           name: metrics
           protocol: TCP
         readinessProbe:
-          failureThreshold: 5
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 8080
-          initialDelaySeconds: 3
-          periodSeconds: 3
+          initialDelaySeconds: 1
+          periodSeconds: 1
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           capabilities:
             drop:
             - ALL
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: true
           runAsNonRoot: true
         volumeMounts:
         - mountPath: /var/run/data/dapr-scheduler/
           name: dapr-scheduler-data-dir
           readOnly: false
+        - mountPath: /tmp
+          name: dapr-scheduler-writeable-identity
         - mountPath: /var/run/secrets/dapr.io/tls
           name: dapr-trust-bundle
           readOnly: true
@@ -1374,6 +1446,8 @@ spec:
         fsGroup: 65532
       serviceAccountName: dapr-scheduler
       volumes:
+      - emptyDir: {}
+        name: dapr-scheduler-writeable-identity
       - configMap:
           name: dapr-trust-bundle
         name: dapr-trust-bundle
@@ -1385,15 +1459,16 @@ spec:
               expirationSeconds: 600
               path: token
   volumeClaimTemplates:
-  - metadata:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
       name: dapr-scheduler-data-dir
     spec:
       accessModes:
       - ReadWriteOnce
       resources:
         requests:
-          storage: 1Gi
-      storageClassName: null
+          storage: 16Gi
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -1401,10 +1476,10 @@ metadata:
   labels:
     app: dapr-scheduler-server
     app.kubernetes.io/component: scheduler
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-scheduler-server-disruption-budget
   namespace: dapr-system
 spec:
@@ -1413,20 +1488,20 @@ spec:
     matchLabels:
       app: dapr-scheduler-server
       app.kubernetes.io/component: scheduler
-      app.kubernetes.io/managed-by: helm
+      app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: dapr
       app.kubernetes.io/part-of: dapr
-      app.kubernetes.io/version: 1.14.1
+      app.kubernetes.io/version: 1.18.0
 ---
 apiVersion: dapr.io/v1alpha1
 kind: Configuration
 metadata:
   labels:
     app.kubernetes.io/component: config
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: daprsystem
   namespace: dapr-system
 spec:
@@ -1443,10 +1518,10 @@ metadata:
   labels:
     app: dapr-sidecar-injector
     app.kubernetes.io/component: sidecar-injector
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.14.1
+    app.kubernetes.io/version: 1.18.0
   name: dapr-sidecar-injector
 webhooks:
 - admissionReviewVersions:

--- a/dapr/internal/configure-pipeline/dependencies/dapr.yaml
+++ b/dapr/internal/configure-pipeline/dependencies/dapr.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-injector
   namespace: dapr-system
 ---
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-operator
   namespace: dapr-system
 ---
@@ -30,7 +30,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-placement
   namespace: dapr-system
 ---
@@ -42,7 +42,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-scheduler
   namespace: dapr-system
 ---
@@ -54,7 +54,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-sentry
   namespace: dapr-system
 ---
@@ -66,7 +66,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-injector
   namespace: dapr-system
 rules:
@@ -99,7 +99,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-operator
   namespace: dapr-system
 rules:
@@ -151,7 +151,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-sentry
   namespace: dapr-system
 rules:
@@ -193,7 +193,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: secret-reader
   namespace: dapr-system
 rules:
@@ -212,7 +212,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-injector
 rules:
 - apiGroups:
@@ -246,7 +246,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-operator-admin
 rules:
 - apiGroups:
@@ -343,7 +343,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-placement
 rules: []
 ---
@@ -355,7 +355,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-scheduler
 rules:
 - apiGroups:
@@ -375,7 +375,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-sentry
 rules:
 - apiGroups:
@@ -409,7 +409,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-injector
   namespace: dapr-system
 roleRef:
@@ -429,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-operator
   namespace: dapr-system
 roleRef:
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-secret-reader
   namespace: dapr-system
 roleRef:
@@ -469,7 +469,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-sentry
   namespace: dapr-system
 roleRef:
@@ -489,7 +489,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-injector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -508,7 +508,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-operator-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -527,7 +527,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-placement
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -546,7 +546,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-scheduler
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -565,7 +565,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-sentry
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-trust-bundle
   namespace: dapr-system
 ---
@@ -598,7 +598,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-trust-bundle
   namespace: dapr-system
 ---
@@ -614,7 +614,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-api
   namespace: dapr-system
 spec:
@@ -648,7 +648,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-placement-server
   namespace: dapr-system
 spec:
@@ -679,7 +679,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-scheduler-server
   namespace: dapr-system
 spec:
@@ -712,7 +712,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-scheduler-server-a
   namespace: dapr-system
 spec:
@@ -745,7 +745,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-sentry
   namespace: dapr-system
 spec:
@@ -774,7 +774,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-sidecar-injector
   namespace: dapr-system
 spec:
@@ -799,7 +799,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-webhook
   namespace: dapr-system
 spec:
@@ -820,7 +820,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-operator
   namespace: dapr-system
 spec:
@@ -841,7 +841,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: dapr
         app.kubernetes.io/part-of: dapr
-        app.kubernetes.io/version: 1.18.0
+        app.kubernetes.io/version: 1.18.1
     spec:
       affinity:
         nodeAffinity:
@@ -872,7 +872,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/dapr/operator:1.18.0
+        image: ghcr.io/dapr/operator:1.18.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -937,7 +937,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-sentry
   namespace: dapr-system
 spec:
@@ -958,7 +958,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: dapr
         app.kubernetes.io/part-of: dapr
-        app.kubernetes.io/version: 1.18.0
+        app.kubernetes.io/version: 1.18.1
     spec:
       affinity:
         nodeAffinity:
@@ -987,7 +987,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/dapr/sentry:1.18.0
+        image: ghcr.io/dapr/sentry:1.18.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -1036,7 +1036,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-sidecar-injector
   namespace: dapr-system
 spec:
@@ -1057,7 +1057,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: dapr
         app.kubernetes.io/part-of: dapr
-        app.kubernetes.io/version: 1.18.0
+        app.kubernetes.io/version: 1.18.1
     spec:
       affinity:
         nodeAffinity:
@@ -1090,7 +1090,7 @@ spec:
         - name: KUBE_CLUSTER_DOMAIN
           value: cluster.local
         - name: SIDECAR_IMAGE
-          value: ghcr.io/dapr/daprd:1.18.0
+          value: ghcr.io/dapr/daprd:1.18.1
         - name: SIDECAR_IMAGE_PULL_POLICY
           value: IfNotPresent
         - name: SIDECAR_RUN_AS_NON_ROOT
@@ -1115,7 +1115,7 @@ spec:
           value: placement
         - name: ACTORS_SERVICE_ADDRESS
           value: dapr-placement-server:50005
-        image: ghcr.io/dapr/injector:1.18.0
+        image: ghcr.io/dapr/injector:1.18.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -1176,7 +1176,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-placement-server
   namespace: dapr-system
 spec:
@@ -1199,7 +1199,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: dapr
         app.kubernetes.io/part-of: dapr
-        app.kubernetes.io/version: 1.18.0
+        app.kubernetes.io/version: 1.18.1
     spec:
       affinity:
         nodeAffinity:
@@ -1240,7 +1240,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/dapr/placement:1.18.0
+        image: ghcr.io/dapr/placement:1.18.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -1303,7 +1303,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-scheduler-server
   namespace: dapr-system
 spec:
@@ -1326,7 +1326,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: dapr
         app.kubernetes.io/part-of: dapr
-        app.kubernetes.io/version: 1.18.0
+        app.kubernetes.io/version: 1.18.1
     spec:
       affinity:
         nodeAffinity:
@@ -1397,7 +1397,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: ghcr.io/dapr/scheduler:1.18.0
+        image: ghcr.io/dapr/scheduler:1.18.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -1479,7 +1479,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-scheduler-server-disruption-budget
   namespace: dapr-system
 spec:
@@ -1491,7 +1491,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: dapr
       app.kubernetes.io/part-of: dapr
-      app.kubernetes.io/version: 1.18.0
+      app.kubernetes.io/version: 1.18.1
 ---
 apiVersion: dapr.io/v1alpha1
 kind: Configuration
@@ -1501,7 +1501,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: daprsystem
   namespace: dapr-system
 spec:
@@ -1521,7 +1521,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dapr
     app.kubernetes.io/part-of: dapr
-    app.kubernetes.io/version: 1.18.0
+    app.kubernetes.io/version: 1.18.1
   name: dapr-sidecar-injector
 webhooks:
 - admissionReviewVersions:

--- a/dapr/internal/scripts/fetch-deps
+++ b/dapr/internal/scripts/fetch-deps
@@ -7,7 +7,7 @@ DEPENDENCIES_DIR=${PWD}/configure-pipeline/dependencies
 helm repo add dapr https://dapr.github.io/helm-charts/
 helm repo update
 
-VERSION=1.18.0
+VERSION=1.18.1
 mkdir -p ${DEPENDENCIES_DIR}
 helm show crds dapr/dapr --version ${VERSION} > ${DEPENDENCIES_DIR}/crds.yaml
 DIR=$(mktemp -d)

--- a/dapr/internal/scripts/fetch-deps
+++ b/dapr/internal/scripts/fetch-deps
@@ -7,7 +7,7 @@ DEPENDENCIES_DIR=${PWD}/configure-pipeline/dependencies
 helm repo add dapr https://dapr.github.io/helm-charts/
 helm repo update
 
-VERSION=1.16.0
+VERSION=1.18.0
 mkdir -p ${DEPENDENCIES_DIR}
 helm show crds dapr/dapr --version ${VERSION} > ${DEPENDENCIES_DIR}/crds.yaml
 DIR=$(mktemp -d)


### PR DESCRIPTION
## Description

Updates the Dapr promise dependencies to the latest Dapr release, **v1.18.0** (released 2026-06-10).

Changes:
- `dapr/internal/scripts/fetch-deps`: `VERSION` `1.16.0` → `1.18.0`
- Regenerated `dapr/internal/configure-pipeline/dependencies/dapr.yaml` and `crds.yaml` by running `fetch-deps` against the Dapr v1.18.0 Helm chart. All control-plane images (`daprd`, `injector`, `operator`, `placement`, `scheduler`, `sentry`) and `app.kubernetes.io/version` labels now resolve to `1.18.0`; the bundled CRDs are refreshed to the 1.18.0 chart.

Generated with helm v3.14.3 + `kubectl kustomize` (v1.29.2), matching the existing tooling in `fetch-deps`.